### PR TITLE
If logger passed in has a serializer defined do not override with new serializer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/index.js
+++ b/index.js
@@ -57,8 +57,8 @@ module.exports = function (options, logger) {
 
   logger = logger.child(
     { serializers:
-      { req: requestSerializer
-      , res: logger.constructor.stdSerializers.res
+      { req: logger.serializers && logger.serializers.req || requestSerializer
+      , res: logger.serializers && logger.serializers.res || logger.constructor.stdSerializers.res
       }
     }
   )


### PR DESCRIPTION
The module is currently always overriding the `req` and `res` serializers on the child `req.log` logger.

This PR has 2 changes...

1.  do not manually set the `res` serializer on the child logger.  
The `res` serializer on the child logger  is currently being set to the bunyan default `res` serializer which is auto included by bunyan on the parent logger. If a child does not define a serializer, bunyan will use the parents serializer. So by default it will use the standard `res` serializer without needing to define it.

1.  Only set the `res` serializer on the child logger if the parent logger is using the default `req` serializer.  
This is so that if the parent has a custom `req` serializer defined you do not overwrite it on the child. Right now, the child logger defined in the module will always use its own serializer even if the logger passed in already has a custom serializer defined.  This PR adds a check to only add a new `req` serializer if the parent logger did not define a custom `req` serializer.