### PR TITLE
Implement `requestStart` option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -85,6 +85,14 @@ The request id is also available as `req.reqId`.
 
 - Eg: `[ 'Authorization' ]`
 
+**`requestStart`** Default: `false`
+
+- Log the start of the request.
+
+**`verbose`** Default: `false`
+
+- Log `req` and `res` for `request start` and `request finish`.
+
 
 ## License
 


### PR DESCRIPTION
Controls whether or not the 'request start' is logged. If set to `'verbose'`
then we log `req` and `res` as well. Defaults to `true`.

closes #2 (?)