### PR TITLE
Support excluding request headers from log output

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -100,7 +100,13 @@ serializer instead of the default one which is using `req.originalUrl` instead.
 
 **`obscureHeaders`** Default: `null`
 
-- Set to an array with header nams to remove them from log output.
+- Set to an array with header names to hide header values from log output. The output will still show header names, with value set to `null`.
+
+- Eg: `[ 'Authorization' ]`
+
+**`excludeHeaders`** Default: `null`
+
+- Set to an array with header names to remove them from log output.
 
 - Eg: `[ 'Authorization' ]`
 

--- a/index.js
+++ b/index.js
@@ -25,21 +25,16 @@ module.exports = function (options, logger) {
     , parentRequestSerializer = logger.serializers && logger.serializers.req
     , level = options.level || 'info'
 
-  if (obscureHeaders && obscureHeaders.length) {
-    obscureHeaders = obscureHeaders.map(function (name) {
-      return name.toLowerCase()
-    })
-  } else {
-    obscureHeaders = false
+  function processHeaderNames(property) {
+    if (property && property.length) {
+      return property.map(function(name) { return name.toLowerCase() })
+    } else {
+      return false
+    }
   }
 
-  if (excludeHeaders && excludeHeaders.length) {
-    excludeHeaders = excludeHeaders.map(function (name) {
-      return name.toLowerCase()
-    })
-  } else {
-    excludeHeaders = false
-  }
+  obscureHeaders = processHeaderNames(obscureHeaders);
+  excludeHeaders = processHeaderNames(excludeHeaders);
 
   function requestSerializer(req) {
     var obj

--- a/index.js
+++ b/index.js
@@ -51,28 +51,20 @@ module.exports = function (options, logger) {
         }
     }
 
-    if (obscureHeaders && obj.headers) {
-      var headers = {}
-      Object.keys(obj.headers).forEach(function(name) {
-        headers[name] = obj.headers[name]
-      })
+    if (obj.headers && (obscureHeaders || excludeHeaders)) {
+      var headers = Object.keys(obj.headers).reduce(function(memo, name) {
+        if (excludeHeaders && excludeHeaders.includes(name)) {
+          return memo
+        }
 
-      for (var i = 0; i < obscureHeaders.length; i++) {
-        headers[ obscureHeaders[i] ] = null
-      }
+        if (obscureHeaders && obscureHeaders.includes(name)) {
+          memo[name] = null
+          return memo
+        }
 
-      obj.headers = headers
-    }
-
-    if (excludeHeaders && obj.headers) {
-      var headers = {}
-      Object.keys(obj.headers).forEach(function(name) {
-        headers[name] = obj.headers[name]
-      })
-
-      for (var i = 0; i < excludeHeaders.length; i++) {
-        delete headers[ excludeHeaders[i] ]
-      }
+        memo[name] = obj.headers[name]
+        return memo
+      }, {})
 
       obj.headers = headers
     }

--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ module.exports = function (options, logger) {
     , additionalRequestFinishData = options.additionalRequestFinishData
     , logName = options.logName || 'req_id'
     , obscureHeaders = options.obscureHeaders
+    , excludeHeaders = options.excludeHeaders
     , requestStart = options.requestStart || false
     , verbose = options.verbose || false
     , parentRequestSerializer = logger.serializers && logger.serializers.req
@@ -30,6 +31,14 @@ module.exports = function (options, logger) {
     })
   } else {
     obscureHeaders = false
+  }
+
+  if (excludeHeaders && excludeHeaders.length) {
+    excludeHeaders = excludeHeaders.map(function (name) {
+      return name.toLowerCase()
+    })
+  } else {
+    excludeHeaders = false
   }
 
   function requestSerializer(req) {
@@ -55,6 +64,19 @@ module.exports = function (options, logger) {
 
       for (var i = 0; i < obscureHeaders.length; i++) {
         headers[ obscureHeaders[i] ] = null
+      }
+
+      obj.headers = headers
+    }
+
+    if (excludeHeaders && obj.headers) {
+      var headers = {}
+      Object.keys(obj.headers).forEach(function(name) {
+        headers[name] = obj.headers[name]
+      })
+
+      for (var i = 0; i < excludeHeaders.length; i++) {
+        delete headers[ excludeHeaders[i] ]
       }
 
       obj.headers = headers

--- a/index.js
+++ b/index.js
@@ -33,8 +33,8 @@ module.exports = function (options, logger) {
     }
   }
 
-  obscureHeaders = processHeaderNames(obscureHeaders);
-  excludeHeaders = processHeaderNames(excludeHeaders);
+  obscureHeaders = processHeaderNames(obscureHeaders)
+  excludeHeaders = processHeaderNames(excludeHeaders)
 
   function requestSerializer(req) {
     var obj
@@ -52,7 +52,7 @@ module.exports = function (options, logger) {
     }
 
     if (obj.headers && (obscureHeaders || excludeHeaders)) {
-      var headers = Object.keys(obj.headers).reduce(function(memo, name) {
+      obj.headers = Object.keys(obj.headers).reduce(function(memo, name) {
         if (excludeHeaders && excludeHeaders.includes(name)) {
           return memo
         }
@@ -65,8 +65,6 @@ module.exports = function (options, logger) {
         memo[name] = obj.headers[name]
         return memo
       }, {})
-
-      obj.headers = headers
     }
 
     return obj


### PR DESCRIPTION
Hi @tellnes ,

I'd like to submit a PR for excluding headers from log output. When working in development I often find the log output too noisy, but I still want to be able to inspect `req` and `res`. This option follows a similar pattern to `obscureHeaders`.