### PR TITLE
add a filter function to let users filter out certain log messages

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -90,7 +90,7 @@ serializer instead of the default one which is using `req.originalUrl` instead.
 
 - A function receiving `req` and `res` as arguments returning an object. The elements in the returned object will be added to the fields in the `request finish` message.
 
-**`filterFunction`** Default: `undefined`
+**`filter`** Default: `undefined`
 
 - A function receiving `req` and `res` as arguments returning a boolean. If this functions return value is truthy it will skip all logging for this request/response.
 

--- a/Readme.md
+++ b/Readme.md
@@ -90,6 +90,10 @@ serializer instead of the default one which is using `req.originalUrl` instead.
 
 - A function receiving `req` and `res` as arguments returning an object. The elements in the returned object will be added to the fields in the `request finish` message.
 
+**`filterFunction`** Default: `undefined`
+
+- A function receiving `req` and `res` as arguments returning a boolean. If this functions return value is truthy it will skip all logging for this request/response.
+
 **`logName`** Default: `'req_id'`
 
 - The name for the request id in the log output.

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ module.exports = function (options, logger) {
     , obscureHeaders = options.obscureHeaders
     , requestStart = options.requestStart || false
     , verbose = options.verbose || false
-    , filterFunction = options.filterFunction || false
+    , filter = options.filterFunction || false
     , parentRequestSerializer = logger.serializers && logger.serializers.req
     , level = options.level || 'info'
 

--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ module.exports = function (options, logger) {
     , obscureHeaders = options.obscureHeaders
     , requestStart = options.requestStart || false
     , verbose = options.verbose || false
+    , filterFunction = options.filterFunction || false
     , parentRequestSerializer = logger.serializers && logger.serializers.req
     , level = options.level || 'info'
 
@@ -72,6 +73,12 @@ module.exports = function (options, logger) {
   )
 
   return function (req, res, next) {
+
+    if (filterFunction && filterFunction(req, res)) {
+        next()
+        return
+    }
+
     var id = req[propertyName]
           || req.headers[headerNameLower]
           || uuid()
@@ -90,6 +97,7 @@ module.exports = function (options, logger) {
       if (verbose) reqStartData.res = res
       req.log[level](reqStartData, 'request start')
     }
+
     res.on('finish', function() {
       var reqFinishData =
         { res: res
@@ -106,6 +114,7 @@ module.exports = function (options, logger) {
       }
       res.log[level](reqFinishData, 'request finish')
     })
+
     res.on('close', function () {
       res.log.warn(
           { req: req


### PR DESCRIPTION
We specifically need to filter out requests with a certain UA because balancer ping checkers in front of our app are creating lots of noise. Could be useful for all sorts of things though.

Example:

```javascript
app.use(bunyanMiddleware({
    obscureHeaders: ['cookie'],
    logger: logger().express(),
    filterFunction: (req) => {
        return lodash.get(req, 'headers["user-agent"]') === 'libadi-telem';
    }
}));
```