### PR TITLE
export interfaces in d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,24 +3,27 @@ import { Request, Response, RequestHandler } from 'express'
 
 export = middleware
 
-interface Params {
-  headerName?: string
-  propertyName?: string
-  additionalRequestFinishData?: { (req: Request, res: Response): object }
-  logName?: string
-  obscureHeaders?: string[]
-  excludeHeaders?: string[]
-  requestStart?: boolean
-  verbose?: boolean
-  level?: 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'fatal'
-  filter?: { (req: Request, res: Response): boolean }
-}
-interface ParamsWithLogger extends Params {
-  logger: Logger
-}
-declare function middleware(params: ParamsWithLogger): RequestHandler
-declare function middleware(params: Params, logger: Logger): RequestHandler
+
+declare function middleware(params: middleware.ParamsWithLogger): RequestHandler
+declare function middleware(params: middleware.Params, logger: Logger): RequestHandler
 declare function middleware(logger: Logger): RequestHandler
+declare namespace middleware {
+  export interface Params {
+    headerName?: string
+    propertyName?: string
+    additionalRequestFinishData?: { (req: Request, res: Response): object }
+    logName?: string
+    obscureHeaders?: string[]
+    excludeHeaders?: string[]
+    requestStart?: boolean
+    verbose?: boolean
+    level?: 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'fatal'
+    filter?: { (req: Request, res: Response): boolean }
+  }
+  export interface ParamsWithLogger extends Params {
+    logger: Logger
+  }
+}
 
 
 declare module 'express' {


### PR DESCRIPTION
It's useful to be able to access the `Params` types in consuming libraries. This enables that use.

E.g.
```typescript
import bunyanMiddleware = require('bunyan-middleware');

const params: bunyanMiddleware.Params = {
  headerName: 'reqId'
};
```