### PR TITLE
No longer warns on res.close event

### DIFF
--- a/index.js
+++ b/index.js
@@ -119,16 +119,6 @@ module.exports = function (options, logger) {
       res.log[level](reqFinishData, 'request finish')
     })
 
-    res.on('close', function () {
-      res.log.warn(
-          { req: req
-          , res: res
-          , duration: getDuration(start)
-          }
-        , 'request socket closed'
-        )
-    })
-
     next()
   }
 }


### PR DESCRIPTION
See: https://github.com/nodejs/node/pull/20611

res.close is always triggered and is no longer considered and error or warning condition

Addresses: https://github.com/tellnes/bunyan-middleware/issues/21

 