### PR TITLE
Add `req_path` field to all logs

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,6 +91,7 @@ module.exports = function (options, logger) {
 
     var prefs = {}
     prefs[logName] = id
+    prefs.req_path = req.path
     req.log = res.log = logger.child(prefs, true)
 
     req[propertyName] = res[propertyName] = id


### PR DESCRIPTION
Would be nice to have the path logged for all request related logs.

Ping @digli

Also: Planning on moving to using your upstream module again rather than our fork.