### PR TITLE
Fix express type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -26,12 +26,14 @@ declare namespace bunyanMiddleware {
 }
 
 
-declare module 'express' {
-  export interface Request {
-    log: Logger
-    reqId: string
-  }
-  export interface Response {
-    log: Logger
+declare global {
+  namespace Express {
+    export interface Request {
+      log: Logger
+      reqId: string
+    }
+    export interface Response {
+      log: Logger
+    }
   }
 }


### PR DESCRIPTION
This PR cherry-picks just the type definition fixes from #24.

A recent change to the `express.static` type (DefinitelyTyped/DefinitelyTyped#48964) exacerbated this problem and causes `express.static` usage to fail if `bunyan-middleware` has been imported.

```
src/lib/express.ts:47:16 - error TS2769: No overload matches this call.
  The last overload gave the following error.
    Argument of type 'RequestHandler<Response<any>>' is not assignable to parameter of type 'Application'.

47   app.use("/", express.static("./assets"));
                  ~~~~~~~~~~~~~~~~~~~~~~~~~~
```